### PR TITLE
Added Maven Central Badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Partial Build Plugin
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.lesfurets/partial-build-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.lesfurets/partial-build-plugin)
+
 [![Build Status](https://travis-ci.org/lesfurets/partial-build-plugin.svg?branch=develop)](https://travis-ci.org/lesfurets/partial-build-plugin)
 
 A maven plugin for partially building multi-module projects based on changes in the Git repository.


### PR DESCRIPTION
Hi there, 

No badge in the README.md informs prospective users, that this software is also published to maven central. For me this created the impression that it's just a "playground fork" from @vackosar and not intended for production use.

I suggest to add the badge:

[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.lesfurets/partial-build-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.lesfurets/partial-build-plugin)

Best,
Max